### PR TITLE
CMB coupling added

### DIFF
--- a/batch/COMPILE_mhd_init.csh
+++ b/batch/COMPILE_mhd_init.csh
@@ -10,7 +10,7 @@
 cd ../utils/mhd_init
 rm -f mhd_init
 
-mpif77 -shared-intel -fpp -g -O3 -xhost -DBINARY  mhd_init.f90 -o mhd_init  -lm -ldl 
+mpif77 -shared-intel -fpp -g -O3 -xhost -DBINARY -DCMB_coupling mhd_init.f90 -o mhd_init  -lm -ldl 
 
 
 #mpif77 -shared-intel -fpp -g -O3 -xhost -DBINARY -DDEBUG -DNGP mhd_init.f90 -o mhd_init  -lsrfftw_mpi -lsrfftw -lsfftw_mpi -lsfftw -lm -ldl

--- a/source_threads/fine_velocity_mhd.f90
+++ b/source_threads/fine_velocity_mhd.f90
@@ -36,34 +36,11 @@
     real, parameter :: mproton = 1.6726E-27 ! in kg
     real :: Nprime, Ephys2sim, Econst
     real    :: E_thermal
+    real    :: E_kinetic
     real    :: z
-
-    
-    ! Temperature coupling to CMB for z > z_dec = 150 
-    ! T_CMB(z) evolves as (1+z)*T_CMB 
 
     z = 1./a - 1.
     E_thermal = 0.
-
-    if (z > 150.) then
-      
-        !! Nprime is the number of physical particles represented by each sim particle
-        !! Ephys2sim converts physical energy units (Joules) to simulation units
-        !! Econst stores the remaing numerical factors from Nprime and Ephys2sim
-
-        Econst = (4. / 9.) * 1.e-10
-        Nprime = omega_b * box**3 / mu / mproton / (real(nc) / 2)**3
-        Ephys2sim = a**2 * real(nc)**5 / omega_m**2 / box**5
-
-#ifdef CMB_coupling
-        E_thermal = Econst * Nprime * k_B * T_CMB * (1. + z) * Ephys2sim
-#endif
-
-        ! Else it is no longer coupled to the CMB. 
-        ! Setting E_thermal to zero would mean zero coupling AND zero
-        ! temperature in the baryons, which we don't usually want.             
-
-    endif 
 
 #endif
 
@@ -114,11 +91,6 @@
           acc= a_mid * G * dt * force_f(:,iff,jff,kff,thread)
           gaz=u(:,iu,ju,ku)
           v=gaz(2:4)/gaz(1)
-#ifdef CMB_coupling
-! z>150,u(5)=E_k+E_t,in which E_t coupled with CMB
-! z<150,u(5) evolves naturally 
-          if (z > 150.) gaz(5)=gaz(1)*sum(v**2)/2 + E_thermal
-#endif
           cs=sqrt(abs(gg*(gaz(5)/gaz(1)-sum(v**2)/2)))
           c=cfactor*(abs(v+acc)+cs)
           cmax=max(cmax,maxval(c))
@@ -134,9 +106,40 @@
           u(5,iu,ju,ku)=gaz(5)+sum((gaz(2:4)+gaz(1)*dv/2)*dv) 
           u(2:4,iu,ju,ku)=gaz(2:4)+gaz(1)*dv
 #endif
+
+#ifdef CMB_coupling
+    
+          ! Temperature coupling to CMB for z > z_dec = 150 
+          ! T_CMB(z) evolves as (1+z)*T_CMB 
+
+          if (z > 150.) then
+      
+            !! Nprime is the number of physical particles represented by each sim particle
+            !! Ephys2sim converts physical energy units (Joules) to simulation units
+            !! Econst stores the remaing numerical factors from Nprime and Ephys2sim
+
+            Econst = (4. / 9.) * 1.e-10
+            Nprime = omega_b * box**3 / mu / mproton / real(nc)**3
+            Ephys2sim = a**2 * real(nc)**5 / omega_m**2 / box**5
+            E_thermal = u(1,iu,ju,ku) * Econst * Nprime * k_B * T_CMB * (1. + z) * Ephys2sim
+
+            v=u(2:4,iu,ju,ku)/u(1,iu,ju,ku)
+            E_kinetic=u(1,iu,ju,ku)*sum(v**2)/2
+
+            u(5,iu,ju,ku) = E_kinetic + E_thermal
+
+
+            ! Else it is no longer coupled to the CMB. 
+            ! Setting E_thermal to zero would mean zero coupling AND zero
+            ! temperature in the baryons, which we don't usually want.             
+
+          endif 
+#endif
         enddo
       enddo
     enddo
+            ! using the line below to check the order of Kinetic/Thermal Energy
+            ! print*,'CMB coupling,E_k=',E_kinetic,'E_thermal=',E_thermal
 #endif
 #ifdef DM_VEL_OLD
 !! update dark matter velocity

--- a/source_threads/makefile_mhd
+++ b/source_threads/makefile_mhd
@@ -8,7 +8,7 @@ FFTWINC= -I/scinet/gpc/lib/fftw/intel-intelmpi-3.2.2-medium/include
 
 LDLIBS= -lsrfftw_mpi -lsrfftw -lsfftw_mpi -lsfftw -lm -ldl
 
-FFLAGS=-shared-intel -fpp -g  -O3 -fpic -xhost -i_dynamic -mcmodel=medium -mt_mpi -DDIAG -DBINARY -DNGP -DPPINT -DOPENMP  -DMPI_TIME  -DLRCKCORR -DNGPH -DDISP_MESH -DMHD -DMOVE_GRID_BACK -DMHD_CIC #-DMHD_DEBUG #-DDEBUG_PP_MESH
+FFLAGS=-shared-intel -fpp -g  -O3 -fpic -xhost -i_dynamic -mcmodel=medium -mt_mpi -DDIAG -DBINARY -DNGP -DPPINT -DOPENMP  -DMPI_TIME  -DLRCKCORR -DNGPH -DDISP_MESH -DMHD -DMOVE_GRID_BACK -DMHD_CIC -DCMB_coupling #-DMHD_DEBUG #-DDEBUG_PP_MESH
 
 #OPTIONAL FLAGS :: -DMHD -DDEBUG_CCIC -DDEBUG_CRHO -DDEBUG_RHOC -DPOINTSRC ##-DBFTEST -DXDRIFT -DPID_FLAG -DPP_EXT -DREAD_SEED -DDEBUG_PP_EXT -DChaplygin #-DDEBUG_CFL#-DDEBUG_PP_MESH #-DDEBUG_COARSE_MESH -DMHD #-DPP_EXT -DPID_FLAG #-DDEBUG_PP_EXT #-DREAD_SEED #-DDISP_MESH -DPID_FLAG #-DDEBUG 
 

--- a/utils/mhd_init/mhd_init.f90
+++ b/utils/mhd_init/mhd_init.f90
@@ -788,7 +788,8 @@ contains
     real    :: x,y,z,dx1,dx2,dy1,dy2,dz1,dz2,vf,v(3)
     real    :: E_thermal
 
-    E_thermal = 0.
+    E_thermal=0.
+
     if (z_i > 150.) then
 
         !! Nprime is the number of physical particles represented by each sim
@@ -797,7 +798,7 @@ contains
         !! Econst stores the remaing numerical factors from Nprime and Ephys2sim
 
         Econst = (4. / 9.) * 1.e-10
-        Nprime = omega_b * box**3 / mu / mproton / (ncr / 2)**3
+        Nprime = omega_b * box**3 / mu / mproton / ncr**3
         Ephys2sim = a_i**2 * ncr**5 / omega_m**2 / box**5
 
 #ifdef CMB_coupling


### PR DESCRIPTION
1) IC producer mhd_init.f90 is corrected for CMB coupling.
2) fine_velocity_mhd.f90 is corrected for CMB coupling.
3) add -DCMB_coupling flag in COMPILE_mhd_init.csh 
4) add -DCMB_coupling flag in makefile_mhd

Test result:
1) something wrong with -DREAD_SEED.  It takes 20000 time step to reach only z=0.2.  Thus for the test I removed -DREAD_SEED, the two simulation share the same IC but different random seed.
2) the two simulation have perfect same power spectrum for both DM and gas, even at redshift 150.
3) no difference could be seen in the slices
4) The simulation began from z=200.  It only take 7 steps to reach z=150.  Within the 7 steps, E_k ~10^-6, E_thermal ~ 10^-9.  This explains no difference in slice and power spectrum.
