### PR TITLE
Revise Make_PP_THREADS and timers.f90 for gcc and openmpi 

### DIFF
--- a/source_threads/Make_PP_THREADS
+++ b/source_threads/Make_PP_THREADS
@@ -1,16 +1,16 @@
 SHELL = /bin/sh
 
-FC=mpif77
+FC= mpif77
 
 
 #FFTWLIB=$(MCKENZIE_FFTW_LIB_PATH) #/home/merz/lib/fftw-2.1.5_intel8/lib
 #FFTWINC=$(MCKENZIE_FFTW_INC_PATH) #/home/merz/lib/fftw-2.1.5_intel8/include
 
 LDLIBS= -lsrfftw_mpi -lsrfftw -lsfftw_mpi -lsfftw -lm -ldl
-FFLAGS=-shared-intel -fpp -g -O3 -fpic -xhost -DDIAG -DBINARY -DNGP -DPPINT -DMPI_TIME  -DLRCKCORR -DNGPH -DDISP_MESH #-DPP_EXT  #-DPID_FLAG #-DDEBUG_PP_EXT #-DREAD_SEED #-DDISP_MESH -DPID_FLAG #-DDEBUG 
-#FFLAGS=-dyncom "divar,ivar,rvar,C2RAY_HALO,lvar" -fpp -g -CB -O3 -fpic -xT -DDIAG -DBINARY -DNGP -DPPINT -DDISP_MESH -DMPI_TIME #-DDEBUG 
+FFLAGS= -fopenmp -fallow-argument-mismatch -Wno-error -ffixed-line-length-none -ffree-form -ffree-line-length-none -cpp -g -O3 -fpic -DDIAG -DBINARY -DNGP -DPPINT -DMPI_TIME  -DLRCKCORR -DNGPH -DDISP_MESH #-DPP_EXT  #-DPID_FLAG #-DDEBUG_PP_EXT #-DREAD_SEED #-DDISP_MESH -DPID_FLAG #-DDEBUG
+#FFLAGS=-dyncom "divar,ivar,rvar,C2RAY_HALO,lvar" -fpp -g -CB -O3 -fpic -xT -DDIAG -DBINARY -DNGP -DPPINT -DDISP_MESH -DMPI_TIME #-DDEBUG
 #-DSCALED_IC #-DDEBUG_VEL -fpe3 -check bounds -DDEBUG #-DMHD #-check bounds -DDEBUG #-DDEBUG_LOW #-DDEBUG_VEL -DDEBUG_CCIC -DDEBUG_RHOC -openmp -DDEBUG_LOW
-#FFLAGS=-fpp -g -O0 -CB -DDIAG -DBINARY -DNGP -DPPINT -DDISP_MESH -DMPI_TIME -DDEBUG 
+#FFLAGS=-fpp -g -O0 -CB -DDIAG -DBINARY -DNGP -DPPINT -DDISP_MESH -DMPI_TIME -DDEBUG
 #OPTIONAL FLAGS :: -DMHD -DDEBUG_CCIC -DDEBUG_CRHO -DDEBUG_RHOC -DPOINTSRC ##-DBFTEST -DXDRIFT -DPID_FLAG -DPP_EXT -DREAD_SEED -DDEBUG_PP_EXT -DChaplygin
 
 OBJS=   checkpoint.o coarse_cic_mass.o coarse_cic_mass_buffer.o coarse_force.o coarse_force_buffer.o coarse_mass.o coarse_max_dt.o coarse_mesh.o coarse_power.o coarse_velocity.o cubepm.o delete_particles.o fftw3ds.o fine_cic_mass.o fine_cic_mass_buffer.o fine_mesh.o fine_ngp_mass.o fine_velocity.o halofind.o fftw2.o init_projection.o kernel_initialization.o link_list.o move_grid_back.o mpi_initialization.o particle_initialization.o particle_mesh_threaded.o particle_pass.o projection.o report_pair.o report_force.o set_pair.o indexedsort.o timers.o timestep.o update_position.o variable_initialization.o 

--- a/source_threads/Make_PP_THREADS
+++ b/source_threads/Make_PP_THREADS
@@ -19,10 +19,10 @@ run: cubep3m
 
 
 cubep3m: $(OBJS)
-	$(FC) $(FFLAGS) -openmp  $^ -o $@  $(LDLIBS)
+	$(FC) $(FFLAGS)  $^ -o $@  $(LDLIBS)
 
 cubepm.o: cubepm.f90 
-	$(FC) $(FFLAGS) -openmp -c $<  
+	$(FC) $(FFLAGS) -c $<  
 
 checkpoint.o: checkpoint.f90 
 	$(FC) $(FFLAGS) -c $<
@@ -34,7 +34,7 @@ coarse_cic_mass_buffer.o: coarse_cic_mass_buffer.f90
 	$(FC) $(FFLAGS)  -c $<
 
 coarse_force.o: coarse_force.f90
-	$(FC) $(FFLAGS) -openmp -c $<
+	$(FC) $(FFLAGS) -c $<
 
 coarse_force_buffer.o: coarse_force_buffer.f90
 	$(FC) $(FFLAGS) -c $<
@@ -52,7 +52,7 @@ coarse_power.o: coarse_power.f90
 	$(FC) $(FFLAGS) -c $<
 
 coarse_velocity.o: coarse_velocity.f90 
-	$(FC) $(FFLAGS) -openmp -c $<
+	$(FC) $(FFLAGS) -c $<
 
 delete_particles.o: delete_particles.f90
 	$(FC) $(FFLAGS) -c $<
@@ -67,7 +67,7 @@ fine_cic_mass_buffer.o: fine_cic_mass_buffer.f90
 	$(FC) $(FFLAGS) -c $<
 
 fine_mesh.o: fine_mesh.f90 
-	$(FC) $(FFLAGS) -openmp -c $<
+	$(FC) $(FFLAGS) -c $<
 
 fine_ngp_mass.o: fine_ngp_mass.f90
 	$(FC) $(FFLAGS) -c $<
@@ -106,7 +106,7 @@ particle_initialization.o: particle_initialization.f90
 	$(FC) $(FFLAGS) -c $<
 
 particle_mesh_threaded.o: particle_mesh_threaded.f90
-	$(FC) $(FFLAGS) -openmp -c $<
+	$(FC) $(FFLAGS) -c $<
 
 particle_pass.o: particle_pass.f90
 	$(FC) $(FFLAGS) -c $<
@@ -133,7 +133,7 @@ timestep.o: timestep.f90
 	$(FC) $(FFLAGS) -c $<
 
 update_position.o: update_position.f90
-	$(FC) $(FFLAGS) -openmp -c $<
+	$(FC) $(FFLAGS) -c $<
 
 variable_initialization.o: variable_initialization.f90
 	$(FC) $(FFLAGS) -c $<

--- a/source_threads/timers.f90
+++ b/source_threads/timers.f90
@@ -59,7 +59,7 @@ subroutine datestamp
   implicit none
   character(len=8) :: t
   character(len=8) :: td
-  call time(t)
+  call date_and_time(t)
   call date_and_time(td)
   print *,td,' ',t
 end subroutine datestamp


### PR DESCRIPTION
I add some fflags for gcc and openmpi,delete some fflags which can't use under gcc.
The file "timers.f90" need to change variable type.
Version:
The gcc version I am using is 9.3.0,
hmpi version is 1.1.1 , 
openblas version is 0.3.18, 
fftw version is 2.1.5, 
hdf5 version is 1.10.1